### PR TITLE
Fix prediction label indexing

### DIFF
--- a/Experiment_tracking/PyTorch_Going_Modular/going_modular/predictions.py
+++ b/Experiment_tracking/PyTorch_Going_Modular/going_modular/predictions.py
@@ -74,8 +74,10 @@ def pred_and_plot_image(
     # Plot image with predicted label and probability
     plt.figure()
     plt.imshow(img)
+    pred_label = target_image_pred_label.cpu().item()
+    pred_prob = target_image_pred_probs.max().cpu().item()
     plt.title(
-        f"Pred: {class_names[target_image_pred_label]} | Prob: {target_image_pred_probs.max():.3f}"
+        f"Pred: {class_names[pred_label]} | Prob: {pred_prob:.3f}"
     )
     plt.axis(False)
 

--- a/PyTorch_Going_Modular/going_modular/predictions.py
+++ b/PyTorch_Going_Modular/going_modular/predictions.py
@@ -74,8 +74,10 @@ def pred_and_plot_image(
     # Plot image with predicted label and probability
     plt.figure()
     plt.imshow(img)
+    pred_label = target_image_pred_label.cpu().item()
+    pred_prob = target_image_pred_probs.max().cpu().item()
     plt.title(
-        f"Pred: {class_names[target_image_pred_label]} | Prob: {target_image_pred_probs.max():.3f}"
+        f"Pred: {class_names[pred_label]} | Prob: {pred_prob:.3f}"
     )
     plt.axis(False)
 

--- a/Transfer__learning/helper_functions.py
+++ b/Transfer__learning/helper_functions.py
@@ -229,10 +229,12 @@ def pred_and_plot_image(
     plt.imshow(
         target_image.squeeze().permute(1, 2, 0)
     )  # make sure it's the right size for matplotlib
+    pred_label = target_image_pred_label.cpu().item()
+    pred_prob = target_image_pred_probs.max().cpu().item()
     if class_names:
-        title = f"Pred: {class_names[target_image_pred_label.cpu()]} | Prob: {target_image_pred_probs.max().cpu():.3f}"
+        title = f"Pred: {class_names[pred_label]} | Prob: {pred_prob:.3f}"
     else:
-        title = f"Pred: {target_image_pred_label} | Prob: {target_image_pred_probs.max().cpu():.3f}"
+        title = f"Pred: {pred_label} | Prob: {pred_prob:.3f}"
     plt.title(title)
     plt.axis(False)
 

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -229,10 +229,12 @@ def pred_and_plot_image(
     plt.imshow(
         target_image.squeeze().permute(1, 2, 0)
     )  # make sure it's the right size for matplotlib
+    pred_label = target_image_pred_label.cpu().item()
+    pred_prob = target_image_pred_probs.max().cpu().item()
     if class_names:
-        title = f"Pred: {class_names[target_image_pred_label.cpu()]} | Prob: {target_image_pred_probs.max().cpu():.3f}"
+        title = f"Pred: {class_names[pred_label]} | Prob: {pred_prob:.3f}"
     else:
-        title = f"Pred: {target_image_pred_label} | Prob: {target_image_pred_probs.max().cpu():.3f}"
+        title = f"Pred: {pred_label} | Prob: {pred_prob:.3f}"
     plt.title(title)
     plt.axis(False)
 


### PR DESCRIPTION
## Summary
- handle tensor outputs when indexing class names in `pred_and_plot_image`
- apply same fix to modular prediction utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689117c635048324be3ebaaa4f50906d