### PR TITLE
Resolve dataset paths from repository root

### DIFF
--- a/PyTorch_Going_Modular/going_modular/train.py
+++ b/PyTorch_Going_Modular/going_modular/train.py
@@ -1,8 +1,6 @@
-"""
-Trains a PyTorch image classification model using device-agnostic code.
-"""
+"""Trains a PyTorch image classification model using device-agnostic code."""
 
-import os
+from pathlib import Path
 
 import torch
 
@@ -18,9 +16,10 @@ BATCH_SIZE = 32
 HIDDEN_UNITS = 10
 LEARNING_RATE = 0.001
 
-# Setup directories
-train_dir = "data/pizza_steak_sushi/train"
-test_dir = "data/pizza_steak_sushi/test"
+# Setup directories relative to the repository root
+data_dir = Path(__file__).resolve().parents[2] / "data" / "pizza_steak_sushi"
+train_dir = data_dir / "train"
+test_dir = data_dir / "test"
 
 # Setup target device
 device = "cuda" if torch.cuda.is_available() else "cpu"

--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ pip install matplotlib pillow tensorboard
 
 ### Training
 
+The training script builds the dataset paths relative to the repository root, so it can be executed from anywhere as long as the data lives in `data/pizza_steak_sushi`:
+
 ```bash
-cd PyTorch_Going_Modular/going_modular
-python train.py
+python PyTorch_Going_Modular/going_modular/train.py
 ```
 
 TensorBoard logs are written to `Experiment_tracking/runs` and can be viewed with:


### PR DESCRIPTION
## Summary
- Use `Path` to construct training and test directories from the repository root so the script works regardless of the working directory
- Update README training instructions accordingly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891207d9ab483249454133e606fca2a