### PR TITLE
Conditionally enable DataLoader pinned memory

### DIFF
--- a/Experiment_tracking/PyTorch_Going_Modular/going_modular/data_setup.py
+++ b/Experiment_tracking/PyTorch_Going_Modular/going_modular/data_setup.py
@@ -1,9 +1,7 @@
-"""
-Contains functionality for creating PyTorch DataLoaders for 
-image classification data.
-"""
+"""Functions for creating DataLoaders for image classification data."""
 import os
 
+import torch
 from torch.utils.data import DataLoader
 from torchvision import datasets, transforms
 
@@ -47,19 +45,21 @@ def create_dataloaders(
   class_names = train_data.classes
 
   # Turn images into data loaders
+  pin_memory = torch.cuda.is_available()
+
   train_dataloader = DataLoader(
       train_data,
       batch_size=batch_size,
       shuffle=True,
       num_workers=num_workers,
-      pin_memory=True,
+      pin_memory=pin_memory,
   )
   test_dataloader = DataLoader(
       test_data,
       batch_size=batch_size,
       shuffle=False,
       num_workers=num_workers,
-      pin_memory=True,
+      pin_memory=pin_memory,
   )
 
   return train_dataloader, test_dataloader, class_names

--- a/PyTorch_Going_Modular/going_modular/data_setup.py
+++ b/PyTorch_Going_Modular/going_modular/data_setup.py
@@ -1,9 +1,7 @@
-"""
-Contains functionality for creating PyTorch DataLoaders for 
-image classification data.
-"""
+"""Functions for creating DataLoaders for image classification data."""
 import os
 
+import torch
 from torch.utils.data import DataLoader
 from torchvision import datasets, transforms
 
@@ -47,19 +45,21 @@ def create_dataloaders(
   class_names = train_data.classes
 
   # Turn images into data loaders
+  pin_memory = torch.cuda.is_available()
+
   train_dataloader = DataLoader(
       train_data,
       batch_size=batch_size,
       shuffle=True,
       num_workers=num_workers,
-      pin_memory=True,
+      pin_memory=pin_memory,
   )
   test_dataloader = DataLoader(
       test_data,
       batch_size=batch_size,
       shuffle=False,
       num_workers=num_workers,
-      pin_memory=True,
+      pin_memory=pin_memory,
   )
 
   return train_dataloader, test_dataloader, class_names

--- a/PyTorch_paper_replicating/PyTorch_Going_Modular/going_modular/data_setup.py
+++ b/PyTorch_paper_replicating/PyTorch_Going_Modular/going_modular/data_setup.py
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0d303932c63be69bfc77a7a7522014fc1e52961fa18a2a9142e2dcd272ff96e7
-size 2047
+oid sha256:5109114358bdfa1dd2d700f3b7b1bdb4e0ee05759ab11e2d14bbfbbec36a75c8
+size 2066

--- a/Transfer__learning/PyTorch_Going_Modular/going_modular/data_setup.py
+++ b/Transfer__learning/PyTorch_Going_Modular/going_modular/data_setup.py
@@ -1,9 +1,7 @@
-"""
-Contains functionality for creating PyTorch DataLoaders for 
-image classification data.
-"""
+"""Functions for creating DataLoaders for image classification data."""
 import os
 
+import torch
 from torch.utils.data import DataLoader
 from torchvision import datasets, transforms
 
@@ -47,19 +45,21 @@ def create_dataloaders(
   class_names = train_data.classes
 
   # Turn images into data loaders
+  pin_memory = torch.cuda.is_available()
+
   train_dataloader = DataLoader(
       train_data,
       batch_size=batch_size,
       shuffle=True,
       num_workers=num_workers,
-      pin_memory=True,
+      pin_memory=pin_memory,
   )
   test_dataloader = DataLoader(
       test_data,
       batch_size=batch_size,
       shuffle=False,
       num_workers=num_workers,
-      pin_memory=True,
+      pin_memory=pin_memory,
   )
 
   return train_dataloader, test_dataloader, class_names


### PR DESCRIPTION
## Summary
- Ensure all modular `data_setup` utilities only use DataLoader pinned memory when CUDA is available.

## Testing
- `pytest`
- `python PyTorch_Going_Modular/going_modular/train.py` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_689125e480408324b246cda84db1f6f1