### PR TITLE
Add Streamlit interface for food classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ Eğitim sırasında oluşan TensorBoard günlükleri `Experiment_tracking/runs` 
 tensorboard --logdir Experiment_tracking/runs
 ```
 
+## Web Arayüzü ile Sınıflandırma
+Eğitilen modeli Streamlit tabanlı basit bir arayüz üzerinden denemek için:
+```bash
+streamlit run app.py
+```
+Komut çalıştıktan sonra açılan sayfadan bir görsel yükleyip model tahminini görebilirsiniz.
+Model yalnızca pizza, biftek ve suşi sınıfları için eğitimlidir; farklı yiyecekler yanlış sonuç verebilir.
+
 ## Testleri Çalıştırma
 Yardımcı fonksiyonların doğru çalıştığından emin olmak için birim testlerini çalıştırın:
 ```bash

--- a/app.py
+++ b/app.py
@@ -1,0 +1,50 @@
+import streamlit as st
+import torch
+from torchvision import transforms
+from PIL import Image
+from pathlib import Path
+
+from PyTorch_Going_Modular.going_modular import model_builder
+
+# Sınıf isimleri
+CLASS_NAMES = ["pizza", "steak", "sushi"]
+
+# Modeli yükleme fonksiyonu
+@st.cache_resource
+def load_model():
+    weights_path = Path("PyTorch_Going_Modular/models/05_going_modular_script_mode_tinyvgg_model.pth")
+    model = model_builder.TinyVGG(input_shape=3, hidden_units=10, output_shape=len(CLASS_NAMES))
+    model.load_state_dict(torch.load(weights_path, map_location="cpu"))
+    model.eval()
+    return model
+
+model = load_model()
+
+# Başlık
+st.title("Gıda Sınıflandırma")
+st.write(
+    "Bu demo model yalnızca **pizza**, **biftek** ve **suşi** sınıflarını içerir. "
+    "Diğer yiyecekler yanlış sınıflandırılabilir."
+)
+
+# Dosya yükleyici
+uploaded_file = st.file_uploader("Bir görüntü yükleyin", type=["jpg", "jpeg", "png"])
+
+if uploaded_file is not None:
+    image = Image.open(uploaded_file).convert("RGB")
+    st.image(image, caption="Yüklenen Görüntü", use_column_width=True)
+
+    transform = transforms.Compose([transforms.Resize((64, 64)), transforms.ToTensor()])
+    image_tensor = transform(image).unsqueeze(0)
+
+    with torch.inference_mode():
+        preds = model(image_tensor)
+        probs = torch.softmax(preds, dim=1)
+        pred_label = probs.argmax(dim=1).item()
+        pred_class = CLASS_NAMES[pred_label]
+        pred_prob = probs[0][pred_label].item()
+
+    st.write(f"Tahmin: {pred_class} ({pred_prob:.2f})")
+    st.write("Sınıf olasılıkları:")
+    for class_name, prob in zip(CLASS_NAMES, probs[0]):
+        st.write(f"- {class_name}: {prob:.2f}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ requests
 tensorboard
 imghdr
 pytest
+streamlit


### PR DESCRIPTION
## Summary
- add a simple Streamlit app to load a TinyVGG model and classify uploaded images
- document that the demo model only supports pizza, steak and sushi, and show class probabilities in the UI
- include Streamlit in project requirements

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement torch)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_6891c648b3f08324a563e1ae72da4f1d