### PR TITLE
Add multi-model comparison interface for food classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ source .venv/bin/activate  # Windows için .venv\Scripts\activate
 # Bağımlılıkları yükle
 pip install -r requirements.txt
 
+# Farklı bir dizinden çalışıyorsanız dosya yolunu belirtin
+# pip install -r Food-classification/requirements.txt
+
 # Python 3.13 ve üzeri için TensorBoard'un gerektirdiği `imghdr` modülünü ayrıca yükleyin
 # (bu adım `ModuleNotFoundError: imghdr` hatasını giderir)
 # pip install imghdr
@@ -57,14 +60,7 @@ pip install -r requirements.txt
 ## Veri Seti
 Depo, `data/pizza_steak_sushi` dizininde küçük bir örnek veri setiyle çalışacak şekilde tasarlanmıştır. Dizin mevcut değilse aşağıdaki Python komutu ile indirilebilir:
 ```bash
-python - <<'PY'
-from helper_functions import download_data
-
-download_data(
-    source="https://github.com/mrdbourke/pytorch-deep-learning/raw/main/data/pizza_steak_sushi.zip",
-    destination="pizza_steak_sushi"
-)
-PY
+python download_dataset.py
 ```
 
 ## Model Eğitimi
@@ -78,15 +74,18 @@ tensorboard --logdir Experiment_tracking/runs
 ```
 
 ## Web Arayüzü ile Sınıflandırma
-Eğitilen modeli Streamlit tabanlı etkileşimli arayüz üzerinden deneyebilirsiniz. Arayüz, yüklenen görüntüyü ekranda gösterir,
-model tahmini yapılırken ilerleme çubuğu animasyonu sunar ve sonuçlar balon animasyonuyla kutlanır. Ayrıca her sınıfa ait
-olasılık değerleri çubuk grafik olarak görselleştirilir.
+Eğitilen modeller Streamlit tabanlı arayüz üzerinden karşılaştırmalı olarak denenebilir. Bir görsel yükledikten sonra TinyVGG,
+EfficientNet-B0, EfficientNet-B2 ve ViT-B16 gibi farklı mimariler aynı görüntü üzerinde tahmin yapar. Her bir modelin tahmini
+ve olasılık değerleri tabloda listelenir, sınıf olasılıkları ise çubuk grafik üzerinde birlikte gösterilerek mimariler arası
+farklılıklar incelenebilir.
 
 ```bash
 streamlit run app.py
 ```
 
 Komut çalıştıktan sonra açılan sayfadan bir görsel yükleyip model tahminini animasyonlu olarak izleyebilirsiniz.
+
+> **Hata giderme:** Eğer arayüzü çalıştırırken `_pickle.UnpicklingError: invalid load key, 'v'` hatası alırsanız, model ağırlıkları indirilememiş demektir. `git lfs install` ve `git lfs pull` komutlarını tekrar çalıştırarak eksik dosyaları indirin.
 
 ## Testleri Çalıştırma
 Yardımcı fonksiyonların doğru çalıştığından emin olmak için birim testlerini çalıştırın:

--- a/app.py
+++ b/app.py
@@ -1,57 +1,139 @@
-import time
 import streamlit as st
 import torch
-from torchvision import transforms
+from torchvision import transforms, models
 from PIL import Image
 from pathlib import Path
 import pandas as pd
+from pickle import UnpicklingError
 
 from PyTorch_Going_Modular.going_modular import model_builder
 
-# Sınıf isimleri
+
+# Available class names for predictions
 CLASS_NAMES = ["pizza", "steak", "sushi"]
 
-# Modeli yükleme fonksiyonu
+
+def create_effnet_b0(num_classes: int) -> torch.nn.Module:
+    model = models.efficientnet_b0(weights=None)
+    model.classifier[1] = torch.nn.Linear(model.classifier[1].in_features, num_classes)
+    return model
+
+
+def create_effnet_b2(num_classes: int) -> torch.nn.Module:
+    model = models.efficientnet_b2(weights=None)
+    model.classifier[1] = torch.nn.Linear(model.classifier[1].in_features, num_classes)
+    return model
+
+
+def create_vit_b16(num_classes: int) -> torch.nn.Module:
+    model = models.vit_b_16(weights=None)
+    model.heads.head = torch.nn.Linear(model.heads.head.in_features, num_classes)
+    return model
+
+
+MODEL_INFO = {
+    "TinyVGG": {
+        "path": Path("PyTorch_Going_Modular/models/05_going_modular_script_mode_tinyvgg_model.pth"),
+        "builder": lambda: model_builder.TinyVGG(input_shape=3, hidden_units=10, output_shape=len(CLASS_NAMES)),
+        "transform": transforms.Compose([transforms.Resize((64, 64)), transforms.ToTensor()]),
+    },
+    "EfficientNet-B0": {
+        "path": Path("Experiment_tracking/models/07_effnetb0_data_20_percent_10_epochs.pth"),
+        "builder": lambda: create_effnet_b0(len(CLASS_NAMES)),
+        "transform": transforms.Compose([transforms.Resize((224, 224)), transforms.ToTensor()]),
+    },
+    "EfficientNet-B2": {
+        "path": Path("Experiment_tracking/models/07_effnetb2_data_20_percent_10_epochs.pth"),
+        "builder": lambda: create_effnet_b2(len(CLASS_NAMES)),
+        "transform": transforms.Compose([transforms.Resize((224, 224)), transforms.ToTensor()]),
+    },
+    "ViT-B16": {
+        "path": Path("PyTorch_paper_replicating/models/08_pretrained_vit_feature_extractor_pizza_steak_sushi.pth"),
+        "builder": lambda: create_vit_b16(len(CLASS_NAMES)),
+        "transform": transforms.Compose([transforms.Resize((224, 224)), transforms.ToTensor()]),
+    },
+}
+
+
 @st.cache_resource
-def load_model():
-    weights_path = Path("PyTorch_Going_Modular/models/05_going_modular_script_mode_tinyvgg_model.pth")
-    model = model_builder.TinyVGG(input_shape=3, hidden_units=10, output_shape=len(CLASS_NAMES))
-    model.load_state_dict(torch.load(weights_path, map_location="cpu"))
+def load_model(name: str) -> torch.nn.Module:
+    info = MODEL_INFO[name]
+    path = info["path"]
+
+    if not path.exists():
+        raise FileNotFoundError(f"Model file not found: {path}. Did you run 'git lfs pull'?" )
+
+    # Detect Git LFS pointer files which are plain text and start with 'version https://'
+    try:
+        content = path.read_text()
+        if content.startswith("version https://git-lfs.github.com"):
+            raise RuntimeError(
+                f"{path} is a Git LFS pointer. Install Git LFS and run 'git lfs pull' to download the actual weights."
+            )
+    except UnicodeDecodeError:
+        # Binary file as expected
+        pass
+
+    model = info["builder"]()
+    try:
+        state_dict = torch.load(path, map_location="cpu")
+    except (UnpicklingError, RuntimeError) as e:
+        raise RuntimeError(
+            f"Failed to load weights from {path}. Ensure the file contains a valid PyTorch state dict."
+        ) from e
+
+    model.load_state_dict(state_dict)
     model.eval()
     return model
 
-model = load_model()
 
-# Başlık
-st.title("Gıda Sınıflandırma")
+st.title("Gıda Sınıflandırma Karşılaştırması")
 
-# Dosya yükleyici
-uploaded_file = st.file_uploader("Bir görüntü yükleyin", type=["jpg", "jpeg", "png"])
+selected_models = st.multiselect(
+    "Modelleri seçin",
+    list(MODEL_INFO.keys()),
+    default=list(MODEL_INFO.keys()),
+)
 
-if uploaded_file is not None:
+uploaded_file = st.file_uploader(
+    "Bir görüntü yükleyin", type=["jpg", "jpeg", "png"]
+)
+
+if uploaded_file and selected_models:
     image = Image.open(uploaded_file).convert("RGB")
     st.image(image, caption="Yüklenen Görüntü", use_column_width=True)
 
-    transform = transforms.Compose([transforms.Resize((64, 64)), transforms.ToTensor()])
-    image_tensor = transform(image).unsqueeze(0)
+    results = {}
+    summary_rows = []
 
-    with st.spinner("Model tahmin ediyor..."):
-        progress_bar = st.progress(0)
-        for percent_complete in range(100):
-            time.sleep(0.01)
-            progress_bar.progress(percent_complete + 1)
+    for model_name in selected_models:
+        try:
+            model = load_model(model_name)
+        except Exception as e:
+            st.error(str(e))
+            continue
 
-        with torch.inference_mode():
-            preds = model(image_tensor)
-            probs = torch.softmax(preds, dim=1).squeeze()
+        transform = MODEL_INFO[model_name]["transform"]
+        image_tensor = transform(image).unsqueeze(0)
 
-    pred_label = torch.argmax(probs).item()
-    pred_class = CLASS_NAMES[pred_label]
-    pred_prob = probs[pred_label].item()
+        with st.spinner(f"{model_name} tahmin ediyor..."):
+            with torch.inference_mode():
+                preds = model(image_tensor)
+                probs = torch.softmax(preds, dim=1).squeeze()
 
-    st.success(f"Tahmin: {pred_class} ({pred_prob:.2%})")
-    st.balloons()
+        pred_idx = int(torch.argmax(probs))
+        summary_rows.append(
+            {
+                "Model": model_name,
+                "Tahmin": CLASS_NAMES[pred_idx],
+                "Olasılık": float(probs[pred_idx]),
+            }
+        )
+        results[model_name] = probs.tolist()
 
-    prob_df = pd.DataFrame({"Sınıf": CLASS_NAMES, "Olasılık": probs.tolist()})
-    prob_df = prob_df.set_index("Sınıf")
-    st.bar_chart(prob_df)
+    st.subheader("Tahmin Karşılaştırması")
+    st.table(pd.DataFrame(summary_rows))
+
+    chart_df = pd.DataFrame(results, index=CLASS_NAMES)
+    st.bar_chart(chart_df)
+

--- a/download_dataset.py
+++ b/download_dataset.py
@@ -1,0 +1,8 @@
+"""Download sample pizza/steak/sushi dataset."""
+from helper_functions import download_data
+
+if __name__ == "__main__":
+    download_data(
+        source="https://github.com/mrdbourke/pytorch-deep-learning/raw/main/data/pizza_steak_sushi.zip",
+        destination="pizza_steak_sushi",
+    )


### PR DESCRIPTION
## Summary
- expand Streamlit app to compare TinyVGG, EfficientNet and ViT predictions
- document multi-model interface in README
- clarify dependency installation and provide script to download sample dataset
- handle missing model weights by detecting Git LFS pointer files and warning users

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement torch)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6891d3c28d1c832496b864d872675f04