### PR TITLE
Switch model storage from Git LFS to DVC

### DIFF
--- a/.dvc/.gitignore
+++ b/.dvc/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/tmp

--- a/.dvc/config
+++ b/.dvc/config
@@ -1,0 +1,5 @@
+[core]
+    remote = local
+
+['remote "local"']
+    url = dvc_storage

--- a/.dvcignore
+++ b/.dvcignore
@@ -1,0 +1,2 @@
+.dvc/tmp
+.dvc/cache

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,0 @@
-PyTorch_paper_replicating filter=lfs diff=lfs merge=lfs -text
-PyTorch_paper_replicating/models/08_pretrained_vit_feature_extractor_pizza_steak_sushi.pth filter=lfs diff=lfs merge=lfs -text
-PyTorch_paper_replicating/** filter=lfs diff=lfs merge=lfs -text
-[[:space:]]Model_deployment/** filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+dvc_storage/

--- a/PyTorch_paper_replicating/models/.gitignore
+++ b/PyTorch_paper_replicating/models/.gitignore
@@ -1,0 +1,1 @@
+/08_pretrained_vit_feature_extractor_pizza_steak_sushi.pth

--- a/PyTorch_paper_replicating/models/08_pretrained_vit_feature_extractor_pizza_steak_sushi.pth
+++ b/PyTorch_paper_replicating/models/08_pretrained_vit_feature_extractor_pizza_steak_sushi.pth
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2d83dbaeb0f63ca39264c3f5bb576690f70c9e444b118c1fbe534d9fc59bc249
-size 343271434

--- a/PyTorch_paper_replicating/models/08_pretrained_vit_feature_extractor_pizza_steak_sushi.pth.dvc
+++ b/PyTorch_paper_replicating/models/08_pretrained_vit_feature_extractor_pizza_steak_sushi.pth.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: f1a0482c837deabe771ae773e8d986e5
+  size: 343271434
+  path: 08_pretrained_vit_feature_extractor_pizza_steak_sushi.pth

--- a/README.md
+++ b/README.md
@@ -31,16 +31,9 @@ Gerekli Python paketleri `requirements.txt` dosyasında listelenmiştir.
 
 ### 2. Depoyu Klonlama
 ```bash
-# Git LFS'i etkinleştir
-git lfs install
-
-# Depoyu klonla (LFS dosyalarını klonlama sırasında atla)
-GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/CYBki/Food-classification.git
+# Depoyu klonla
+git clone https://github.com/CYBki/Food-classification.git
 cd Food-classification
-
-# Eksik LFS dosyalarını indirmeyi dene
-git lfs fetch --all
-git lfs pull
 
 # (Opsiyonel) sanal ortam oluştur
 python -m venv .venv
@@ -48,6 +41,9 @@ source .venv/bin/activate  # Windows için .venv\Scripts\activate
 
 # Bağımlılıkları yükle
 pip install -r requirements.txt
+
+# DVC ile gereken model dosyalarını indir
+dvc pull
 
 # Farklı bir dizinden çalışıyorsanız dosya yolunu belirtin
 # pip install -r Food-classification/requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ tensorboard
 imghdr
 pytest
 streamlit
+dvc


### PR DESCRIPTION
## Summary
- replace Git LFS logic with DVC, fetching models via `dvc pull`
- track pretrained ViT weights using DVC and ignore raw weight file
- document and require DVC for pulling models

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_6891efbf03148324926c4299d0d5b069