### PR TITLE
Switch model storage from Git LFS to DVC

### DIFF
--- a/.dvc/.gitignore
+++ b/.dvc/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/tmp

--- a/.dvc/config
+++ b/.dvc/config
@@ -1,0 +1,5 @@
+[core]
+    remote = local
+
+['remote "local"']
+    url = dvc_storage

--- a/.dvcignore
+++ b/.dvcignore
@@ -1,0 +1,2 @@
+.dvc/tmp
+.dvc/cache

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,0 @@
-PyTorch_paper_replicating filter=lfs diff=lfs merge=lfs -text
-PyTorch_paper_replicating/models/08_pretrained_vit_feature_extractor_pizza_steak_sushi.pth filter=lfs diff=lfs merge=lfs -text
-PyTorch_paper_replicating/** filter=lfs diff=lfs merge=lfs -text
-[[:space:]]Model_deployment/** filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+dvc_storage/

--- a/PyTorch_paper_replicating/models/.gitignore
+++ b/PyTorch_paper_replicating/models/.gitignore
@@ -1,0 +1,1 @@
+/08_pretrained_vit_feature_extractor_pizza_steak_sushi.pth

--- a/PyTorch_paper_replicating/models/08_pretrained_vit_feature_extractor_pizza_steak_sushi.pth
+++ b/PyTorch_paper_replicating/models/08_pretrained_vit_feature_extractor_pizza_steak_sushi.pth
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2d83dbaeb0f63ca39264c3f5bb576690f70c9e444b118c1fbe534d9fc59bc249
-size 343271434

--- a/PyTorch_paper_replicating/models/08_pretrained_vit_feature_extractor_pizza_steak_sushi.pth.dvc
+++ b/PyTorch_paper_replicating/models/08_pretrained_vit_feature_extractor_pizza_steak_sushi.pth.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: f1a0482c837deabe771ae773e8d986e5
+  size: 343271434
+  path: 08_pretrained_vit_feature_extractor_pizza_steak_sushi.pth

--- a/README.md
+++ b/README.md
@@ -24,23 +24,16 @@ Food-classification/
 ## Kurulum
 ### 1. Gereksinimler
 - Python 3.8+
-- [Git](https://git-scm.com/) ve [Git LFS](https://git-lfs.com/)
+ - [Git](https://git-scm.com/) ve [DVC](https://dvc.org/)
 - İsteğe bağlı olarak bir sanal ortam
 
 Gerekli Python paketleri `requirements.txt` dosyasında listelenmiştir.
 
 ### 2. Depoyu Klonlama
 ```bash
-# Git LFS'i etkinleştir
-git lfs install
-
-# Depoyu klonla (LFS dosyalarını klonlama sırasında atla)
-GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/CYBki/Food-classification.git
+# Depoyu klonla
+git clone https://github.com/CYBki/Food-classification.git
 cd Food-classification
-
-# Eksik LFS dosyalarını indirmeyi dene
-git lfs fetch --all
-git lfs pull
 
 # (Opsiyonel) sanal ortam oluştur
 python -m venv .venv
@@ -48,6 +41,9 @@ source .venv/bin/activate  # Windows için .venv\Scripts\activate
 
 # Bağımlılıkları yükle
 pip install -r requirements.txt
+
+# DVC ile gereken model dosyalarını indir
+dvc pull
 
 # Farklı bir dizinden çalışıyorsanız dosya yolunu belirtin
 # pip install -r Food-classification/requirements.txt

--- a/app.py
+++ b/app.py
@@ -11,6 +11,9 @@ import shutil
 from PyTorch_Going_Modular.going_modular import model_builder
 
 
+# Repository root (current file lives at project root)
+REPO_ROOT = Path(__file__).resolve().parent
+
 # Available class names for predictions
 CLASS_NAMES = ["pizza", "steak", "sushi"]
 
@@ -63,7 +66,6 @@ def load_model(name: str) -> torch.nn.Module:
     path = info["path"]
 
     if not path.exists():
-        repo_root = Path(__file__).resolve().parent
         dvc_file = path.with_suffix(path.suffix + ".dvc")
         if dvc_file.exists():
             if shutil.which("dvc") is None:
@@ -72,8 +74,8 @@ def load_model(name: str) -> torch.nn.Module:
                 )
             try:
                 subprocess.run(
-                    ["dvc", "pull", str(dvc_file)],
-                    cwd=repo_root,
+                    ["dvc", "pull", str(dvc_file.relative_to(REPO_ROOT))],
+                    cwd=REPO_ROOT,
                     check=True,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,

--- a/app.py
+++ b/app.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pandas as pd
 from pickle import UnpicklingError
 import subprocess
+import shutil
 
 from PyTorch_Going_Modular.going_modular import model_builder
 
@@ -62,69 +63,40 @@ def load_model(name: str) -> torch.nn.Module:
     path = info["path"]
 
     if not path.exists():
-        raise FileNotFoundError(
-            f"Model file not found: {path}. Did you run 'git lfs pull'?"
-        )
-
-    # Check if file is a Git LFS pointer before attempting to load
-    try:
-        # Try to read the first few bytes as text to detect LFS pointer
-        with open(path, 'rb') as f:
-            first_bytes = f.read(50)
-
-        # Check if it's a text file starting with 'version'
-        try:
-            first_text = first_bytes.decode('utf-8')
-            if first_text.startswith("version https://git-lfs.github.com"):
-                repo_root = Path(__file__).resolve().parent
-                try:
-                    subprocess.run(
-                        ["git", "lfs", "pull", "--include", str(path)],
-                        cwd=repo_root,
-                        check=True,
-                        stdout=subprocess.PIPE,
-                        stderr=subprocess.PIPE,
-                    )
-                except Exception as pull_error:
-                    raise RuntimeError(
-                        f"{path} is a Git LFS pointer file and automatic 'git lfs pull' failed: {pull_error}"
-                    )
-                else:
-                    # Re-read bytes after attempting pull
-                    with open(path, 'rb') as f:
-                        first_bytes = f.read(50)
-                    try:
-                        first_text = first_bytes.decode('utf-8')
-                    except UnicodeDecodeError:
-                        first_text = ""
-                    if first_text.startswith("version https://git-lfs.github.com"):
-                        raise RuntimeError(
-                            f"{path} is a Git LFS pointer file. Install Git LFS and run 'git lfs pull' to download the actual model weights."
-                        )
-        except UnicodeDecodeError:
-            # Binary file as expected, continue
-            pass
-    except Exception as e:
-        if "Git LFS" in str(e):
-            raise e
+        repo_root = Path(__file__).resolve().parent
+        dvc_file = path.with_suffix(path.suffix + ".dvc")
+        if dvc_file.exists():
+            if shutil.which("dvc") is None:
+                raise FileNotFoundError(
+                    "DVC command not found. Install DVC and run 'dvc pull' to download the model."
+                )
+            try:
+                subprocess.run(
+                    ["dvc", "pull", str(dvc_file)],
+                    cwd=repo_root,
+                    check=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
+            except subprocess.CalledProcessError as pull_error:
+                raise FileNotFoundError(
+                    f"Model file not found: {path}. Run 'dvc pull' to download the model. "
+                    f"Original error: {pull_error.stderr.decode().strip()}"
+                ) from pull_error
+        if not path.exists():
+            raise FileNotFoundError(
+                f"Model file not found: {path}. Run 'dvc pull' to download the model."
+            )
 
     model = info["builder"]()
     try:
         state_dict = torch.load(path, map_location="cpu")
     except (UnpicklingError, RuntimeError, EOFError) as e:
-        # Check file size - LFS pointers are typically very small
-        file_size = path.stat().st_size
-        if file_size < 1000:  # Less than 1KB is likely a pointer file
-            raise RuntimeError(
-                f"Model file {path} appears to be a Git LFS pointer (size: {file_size} bytes). "
-                f"Install Git LFS and run 'git lfs pull' to download the actual weights."
-            )
-        else:
-            raise RuntimeError(
-                f"Failed to load PyTorch model from {path}. "
-                f"The file might be corrupted or not a valid PyTorch state dict. "
-                f"Original error: {str(e)}"
-            ) from e
+        raise RuntimeError(
+            f"Failed to load PyTorch model from {path}. "
+            f"The file might be corrupted or not a valid PyTorch state dict. "
+            f"Original error: {str(e)}"
+        ) from e
 
     model.load_state_dict(state_dict)
     model.eval()

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ tensorboard
 imghdr
 pytest
 streamlit
+dvc


### PR DESCRIPTION
## Summary
- replace Git LFS logic with DVC, fetching models via `dvc pull`
- track pretrained ViT weights using DVC and ignore raw weight file
- document and require DVC for pulling models
- clarify missing-model errors by checking for a usable `dvc` command

## Testing
- `pip install torch` *(fails: Could not find a version that satisfies the requirement torch (from versions: none))*
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6891efbf03148324926c4299d0d5b069